### PR TITLE
Display processed item counts instead of percent progress

### DIFF
--- a/scripts/run_whisper.py
+++ b/scripts/run_whisper.py
@@ -470,9 +470,14 @@ class AudioProcessorGUI:
         progress_line = None
         self.progress_bar.config(mode='determinate', maximum=100, value=0)
 
-        def on_progress(progress, elapsed, remaining):
+        def on_progress(processed, total, elapsed, remaining):
             nonlocal progress_line
-            msg = f"Прогресс: {progress*100:.1f}% | прошло: {elapsed:.1f}с"
+            processed = int(processed)
+            total_int = int(total) if total else 0
+            msg = f"Обработано: {processed}"
+            if total_int:
+                msg += f" из {total_int}"
+            msg += f" | прошло: {elapsed:.1f}с"
             if remaining is not None:
                 msg += f" | осталось: {remaining:.1f}с"
             if progress_line is not None:
@@ -480,8 +485,13 @@ class AudioProcessorGUI:
             self.log_text.insert(tk.END, msg + "\n")
             progress_line = int(self.log_text.index(tk.END).split('.')[0]) - 2
             self.log_text.see(tk.END)
+            if total_int:
+                self.progress_var.set(f"{processed} из {total_int} обработано")
+            else:
+                self.progress_var.set(f"{processed} обработано")
             self.root.update()
-            self.progress_bar['value'] = progress * 100
+            if total_int:
+                self.progress_bar['value'] = processed / total_int * 100
             if self.stop_event.is_set():
                 raise TranscriptionCancelled()
 
@@ -645,13 +655,9 @@ def transcribe_file(audio_path: Path, model_name: str = "large-v3", progress_cal
                     elapsed = time.time() - start_time
                     rate = self.n / elapsed if elapsed > 0 else 0
                     remaining = (self.total - self.n) / rate if self.total and rate > 0 else None
-                    if self.total:
-                        progress = self.n / self.total
-                    elif remaining is not None:
-                        progress = elapsed / (elapsed + remaining)
-                    else:
-                        progress = 0
-                    self._callback(progress, elapsed, remaining)
+                    processed = int(self.n)
+                    total_items = int(self.total) if self.total else 0
+                    self._callback(processed, total_items, elapsed, remaining)
 
         old_tqdm = tqdm.tqdm
         tqdm.tqdm = partial(TqdmLogger, progress_callback=progress_callback, stop_event=stop_event)


### PR DESCRIPTION
## Summary
- Fix Whisper progress callback so processed counts are passed as integers
- Update GUI progress handler to show current `N из M` items and update the progress bar accordingly, falling back to `N обработано` when total is unknown

## Testing
- `python -m py_compile scripts/run_whisper.py`
- `python - <<'PY'
from pathlib import Path
from scripts.run_whisper import transcribe_file

def cb(p,t,e,r):
    print('progress', p, 'total', t, 'elapsed', round(e,2), 'remaining', r)

try:
    transcribe_file(Path('test.wav'), model_name='tiny', progress_callback=cb)
except Exception as exc:
    print('error', exc)
PY` *(fails: `<urlopen error Tunnel connection failed: 403 Forbidden>`)*

------
https://chatgpt.com/codex/tasks/task_e_6899e269ae348325a63c79b68e53d27a